### PR TITLE
Enable compression feature of Tomcat

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -79,6 +79,7 @@
               redirectPort="8443"
               xpoweredBy="false"
               server=""
+              compression="on"
               proxyPort="${connector.proxy.port}"
               scheme="${connector.scheme}"
               secure="true"


### PR DESCRIPTION
We want the origin to be responsible for compressing responses for
clients that support this feature.

See https://tomcat.apache.org/tomcat-8.5-doc/config/http.html#Standard_Implementation

We are expecting this Docker image to be used behind a reverse-proxy of
some sort. The one we're using immediately does not support compressing
responses. So we're making that the responsibility of Tomcat.

If we (or other consumers of this Docker image) need to change that
decision in the future, we can make it configurable.

But for now, we can hardcode it to be on.