### PR TITLE
Paramaterise `secure` property of the HTTP Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Exported environment variables
 --- | --- | ---
 TOMCAT_HOME                 | usr/local/tomee | Installed location for Tomcat
 TOMCAT_CONNECTOR_PROXY_PORT | 443             | Configure this attribute to specify the server port to be returned for calls to request.getServerPort()
-TOMCAT_CONNECTOR_SCHEME | https           | Set this attribute to the name of the protocol you wish to have returned by calls to request.getScheme()
+TOMCAT_CONNECTOR_SCHEME     | https           | Set this attribute to the name of the protocol you wish to have returned by calls to request.getScheme()
+TOMCAT_CONNECTOR_SECURE     | true            | Set this attribute to true if you wish to have calls to request.isSecure() to return true for requests received by this Connector.  You would usually set this value to _false_ when running tomcat in a localhost mode, and not behind a load balancer
 
 Usage
 -----
@@ -29,15 +30,17 @@ and then run the catalina.sh command to start tomcat:
  ```sh
 ENV TOMCAT_CONNECTOR_PROXY_PORT 8080
 ENV TOMCAT_CONNECTOR_SCHEME http
+ENV TOMCAT_CONNECTOR_SECURE false
 
 CMD CATALINA_OPTS="$CATALINA_OPTS \
     -Dconnector.proxy.port=$TOMCAT_CONNECTOR_PROXY_PORT \
-    -Dconnector.scheme=$TOMCAT_CONNECTOR_SCHEME" \
+    -Dconnector.scheme=$TOMCAT_CONNECTOR_SCHEME \
+    -Dconnector.secure=$TOMCAT_CONNECTOR_SECURE" \
     catalina.sh run
 ```
 
 Alternatively you can specify overrides of the environment variables with runtime arguments:
 
 ```sh
-docker container run -e TOMCAT_CONNECTOR_PROXY_PORT=8080 -e TOMCAT_CONNECTOR_SCHEME=http myhardenedcontainer
+docker container run -e TOMCAT_CONNECTOR_PROXY_PORT=8080 -e TOMCAT_CONNECTOR_SCHEME=http -e TOMCAT_CONNECTOR_SECURE=false myhardenedcontainer
 ```

--- a/server.xml
+++ b/server.xml
@@ -81,7 +81,7 @@
               server=""
               proxyPort="${connector.proxy.port}"
               scheme="${connector.scheme}"
-              secure="true"
+              secure="${connector.secure}"
               URIEncoding="UTF-8"/>
 
     <!-- A "Connector" using the shared thread pool-->


### PR DESCRIPTION
We need to allow the `secure` property of the HTTP connector to be
overridden to false when running Tomcat on a localhost environment and
it is not behind a reverse-proxy that handles TLS termination.

We are adding a new environment variable to the Dockerfile:

* TOMCAT_CONNECTOR_SECURE = true

This is a secure profile by default, suitable for running in production
behind a proxy that terminates TLS.

We are including this in the `CATALINA_OPTS` environment variable that
the image defines.

```sh
ENV CATALINA_OPTS="$CATALINA_OPTS \
-Dconnector.scheme=$TOMCAT_CONNECTOR_SECURE"
```

The property `connector.secure` is referenced in the server.xml file:

```xml
<Connector
port="8080"
protocol="HTTP/1.1"
secure=${connector.secure}/>
```