### PR TITLE
Add common system.properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,4 @@ RUN rm -rf ${TOMCAT_HOME}/webapps/*
 RUN useradd -M tomee && usermod -L tomee && chown -R tomee:tomee ${TOMCAT_HOME}
 USER tomee
 
-COPY server.xml ${TOMCAT_HOME}/conf/
-COPY tomcat-users.xml ${TOMCAT_HOME}/conf/
-COPY tomee.xml ${TOMCAT_HOME}/conf/
+COPY server.xml system.properties tomcat-users.xml tomee.xml ${TOMCAT_HOME}/conf/

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,8 @@
+# all this properties are added at JVM system properties at startup
+# here some default Apache TomEE system properties
+# for more information please see http://tomee.apache.org/properties-listing.html
+
+# allowed packages to be deserialized, by security we denied all by default, tune tomee.serialization.class.whitelist packages to change it
+tomee.serialization.class.whitelist =
+tomee.serialization.class.blacklist = -
+openejb.classloader.forced-load=org.apache.commons.


### PR DESCRIPTION
We aren't configuring this anywhere. So define it once, and delete all
of the other usages in downstream consumers.